### PR TITLE
Adding retries to AWS API calls

### DIFF
--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -43,6 +43,9 @@
 
 -define(METADATA_TOKEN, "X-aws-ec2-metadata-token").
 
+-define(LINEAR_BACK_OFF_MILLIS, 1000).
+-define(MAX_RETRIES, 30).
+
 -type access_key() :: nonempty_string().
 -type secret_access_key() :: nonempty_string().
 -type expiration() :: calendar:datetime() | undefined.

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -17,7 +17,8 @@
          has_credentials/0,
          set_region/1,
          ensure_imdsv2_token_valid/0,
-         api_get_request/2]).
+         api_get_request/2,
+         api_get_request_with_retries/3]).
 
 %% gen-server exports
 -export([start_link/0,
@@ -543,10 +544,18 @@ ensure_credentials_valid() ->
 %% @end
 api_get_request(Service, Path) ->
   rabbit_log:debug("Invoking AWS request {Service: ~p; Path: ~p}...", [Service, Path]),
+  api_get_request_with_retries(Service, Path, ?MAX_RETRIES).
+
+api_get_request_with_retries(Service, Path, Retries) ->
   ensure_credentials_valid(),
   case get(Service, Path) of
-    {ok, {_Headers, Payload}} -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
-                                 {ok, Payload};
+  {ok, {_Headers, Payload}} -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
+                               {ok, Payload};
     {error, {credentials, _}} -> {error, credentials};
-    {error, Message, _}       -> {error, Message}
+    {error, Message, _}       -> if
+                                   Retries < 1 -> {error, Message};
+                                   true -> rabbit_log:debug("Encountered error when calling api ~p, retries remaining ~p", [Message, Retries]),
+                                        timer:sleep(?LINEAR_BACK_OFF_MILLIS),
+                                        api_get_request_with_retries(Service, Path, Retries - 1)
+                                 end
   end.


### PR DESCRIPTION
## Proposed Changes

Adding retry logic to aws `api_get_request`. 

Requests can now handle transient errors from the AWS API. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

N/A
